### PR TITLE
first draft of iM1_8 that uses thrust mode

### DIFF
--- a/moos-ivp-surveyor/src/iM1_8/M1_8.h
+++ b/moos-ivp-surveyor/src/iM1_8/M1_8.h
@@ -15,7 +15,7 @@
 #include <string>
 #include "SockNinja.h"
 #include "Thruster.h"
-#include "VehRotController.h"
+//#include "VehRotController.h"
 #include "MOOS/libMOOSGeodesy/MOOSGeodesy.h"
 #include "MOOS/libMOOS/Thirdparty/AppCasting/AppCastingMOOSApp.h"
 
@@ -57,6 +57,9 @@ protected: // App Specific functions
   bool reportBadMessage(std::string msg, std::string reason="");
   bool GeodesySetup();
   void checkForStalenessOrAllStop();
+  void convertThrustVals(double thrustL, double thrustR,
+			 double& pseac_msg_thrust,
+			 double& pseac_msg_thrust_diff);
 
   
 
@@ -82,7 +85,7 @@ private: // State variables
   CMOOSGeodesy m_geodesy;
   SockNinja    m_ninja;
   Thruster     m_thrust;
-  VehRotController m_rot_ctrl;
+  //VehRotController m_rot_ctrl;
   std::string m_searobot_mode;
 
   bool         m_ivp_allstop;
@@ -118,6 +121,7 @@ private: // State variables
 
   //new controller variables
   bool m_legacy_controller;
+  std::set<std::string> m_valid_USV_control_modes;
   
 };
 


### PR DESCRIPTION
The majority of the changes are in 
`sendMessagesToSocket()`
and I also deleted or commented out references to the rotational controller to avoid confusion. 

The goal of this change is to enable the following autonomy/controls pipeline
**pHelmIvP** -> (DESIRED_SPEED, DESIRED_HEADING) -> **pMarinePID** -> (DESIRED_THRUST, DESIRED_RUDDER) -> **iM1_8** => ($PSEAC,T,... over the socket) => **Frontseat.** 

The thurster class within **iM1_8** ingests DESIRED_THRUST and DESIRED_RUDDER and calculates `thrustL` and `thrustR` per the configuration parameter in **iM1_8** (either _normal_ or _aggro_).   Values for `pseac_msg_thrust` and `pseac_msg_thrust_diff` are calculated in the function `convertThrustVals(...)`


The code for the previous approach (new lines 446 - 508) is retained, but it is commented out from the compiler.   You may want to include the option to use this approach so you can revert back to this mode, maybe by specifying a configuration parameter.  It seems like the variable "m_legacy_controller" could be used for this, but I was not not sure the original intention of this variable and didn't want to cause confusion. 

